### PR TITLE
OS-13-Without-UUID-In-DropDown-Tables: Deleted UUID for 3 tables

### DIFF
--- a/Migration script/openIMIS migration v1.3.0 - v1.4.0.sql
+++ b/Migration script/openIMIS migration v1.3.0 - v1.4.0.sql
@@ -106,18 +106,3 @@ IF COL_LENGTH('tblRole', 'RoleUUID') IS NULL
 BEGIN
 	ALTER TABLE tblRole ADD RoleUUID uniqueidentifier NOT NULL DEFAULT NEWID()
 END
-
-IF COL_LENGTH('tblEducations', 'EducationUUID') IS NULL
-BEGIN
-	ALTER TABLE tblEducations ADD EducationUUID uniqueidentifier NOT NULL DEFAULT NEWID()
-END
-
-IF COL_LENGTH('tblProfessions', 'ProfessionUUID') IS NULL
-BEGIN
-	ALTER TABLE tblProfessions ADD ProfessionUUID uniqueidentifier NOT NULL DEFAULT NEWID()
-END
-
-IF COL_LENGTH('tblRelations', 'RelationUUID') IS NULL
-BEGIN
-	ALTER TABLE tblRelations ADD RelationUUID uniqueidentifier NOT NULL DEFAULT NEWID()
-END


### PR DESCRIPTION
I've removed the UUID for tables:
- tblEducations
- tblProfessions
- tblRelations

**Task:**
https://openimis.atlassian.net/browse/OS-13