### PR TITLE
OP-324: Delete member of family in uspConsumeEnrollment

### DIFF
--- a/Empty databases/openIMIS_ONLINE.sql
+++ b/Empty databases/openIMIS_ONLINE.sql
@@ -9978,15 +9978,9 @@ CREATE PROCEDURE [dbo].[uspConsumeEnrollments](
             -- get the insuree which are not included in "insureeToProcess"
             DECLARE @insureeToDelete TABLE(CHFID NVARCHAR(12))
             INSERT INTO @insureeToDelete(CHFID)
-            SELECT CHFID
-            FROM (
-            SELECT CHFID FROM @insureeToProcess
-            UNION ALL
-            SELECT CHFID FROM @tblInsuree TI
-            ) tbl
-            GROUP BY CHFID
-            HAVING count(*) = 1
-            ORDER BY CHFID;
+            SELECT IP.CHFID FROM @insureeToProcess IP
+            LEFT JOIN @tblInsuree I ON I.CHFID=IP.CHFID
+            WHERE I.CHFID is NULL
 
             -- iterate through insuree to delete - process them to remove from existing family
             -- use SP uspAPIDeleteMemberFamily and 'delete' InsureePolicy also like in webapp 

--- a/Empty databases/openIMIS_ONLINE.sql
+++ b/Empty databases/openIMIS_ONLINE.sql
@@ -9953,6 +9953,62 @@ CREATE PROCEDURE [dbo].[uspConsumeEnrollments](
 			AND TP.isOffline = 0
 			
 
+            /********************************************************************************************************
+                                        CHECK IF SOME INSUREE ARE ABOUT TO DELETE FROM FAMILY	
+            ********************************************************************************************************/
+
+            -- get the family id to process from online database
+            DECLARE @familyIdToProcess TABLE (FamilyId INT)
+            INSERT INTO @familyIdToProcess(FamilyId)
+            SELECT I.FamilyId
+            FROM @tblInsuree TI
+            INNER JOIN tblInsuree I ON TI.CHFID = I.CHFID
+            WHERE I.ValidityTo IS NULL AND TI.isOffline = 1
+            GROUP BY I.FamilyID
+
+            -- get to compare the structure of families (list of insuree) from online database
+            DECLARE @insureeToProcess TABLE(CHFID NVARCHAR(12), FamilyID INT) 
+            INSERT INTO @insureeToProcess(CHFID, FamilyID)
+            SELECT I.CHFID, F.FamilyID FROM tblInsuree I 
+            LEFT JOIN tblFamilies F ON I.FamilyID = F.FamilyID
+            WHERE F.FamilyID IN (SELECT * FROM @familyIdToProcess) AND I.ValidityTo is NULL
+            GROUP BY I.CHFID, F.FamilyID
+
+            -- select the insuree to delete based on received XML payload
+            -- get the insuree which are not included in "insureeToProcess"
+            DECLARE @insureeToDelete TABLE(CHFID NVARCHAR(12))
+            INSERT INTO @insureeToDelete(CHFID)
+            SELECT CHFID
+            FROM (
+            SELECT CHFID FROM @insureeToProcess
+            UNION ALL
+            SELECT CHFID FROM @tblInsuree TI
+            ) tbl
+            GROUP BY CHFID
+            HAVING count(*) = 1
+            ORDER BY CHFID;
+
+            -- iterate through insuree to delete - process them to remove from existing family
+            -- use SP uspAPIDeleteMemberFamily and 'delete' InsureePolicy also like in webapp 
+            IF EXISTS(SELECT 1 FROM @insureeToDelete)
+            BEGIN 
+                DECLARE @CurInsureeCHFID NVARCHAR(12)
+                DECLARE CurInsuree CURSOR FOR SELECT CHFID FROM @insureeToDelete
+                    OPEN CurInsuree
+                        FETCH NEXT FROM CurInsuree INTO @CurInsureeCHFID;
+                        WHILE @@FETCH_STATUS = 0
+                        BEGIN
+                            DECLARE @currentInsureeId INT
+                            SET @currentInsureeId = (SELECT InsureeID FROM tblInsuree WHERE CHFID=@CurInsureeCHFID AND ValidityTo is NULL)
+                            EXEC uspAPIDeleteMemberFamily -2, @CurInsureeCHFID
+                            UPDATE tblInsureePolicy SET ValidityTo = GETDATE() WHERE InsureeId = @currentInsureeId
+                            FETCH NEXT FROM CurInsuree INTO @CurInsureeCHFID;
+                        END
+                    CLOSE CurInsuree
+                DEALLOCATE CurInsuree;	 
+            END
+
+
 			/********************************************************************************************************
 										DELETE REJECTED RECORDS		
 			********************************************************************************************************/

--- a/Migration script/openIMIS migration latest.sql
+++ b/Migration script/openIMIS migration latest.sql
@@ -675,15 +675,9 @@ CREATE PROCEDURE [dbo].[uspConsumeEnrollments](
             -- get the insuree which are not included in "insureeToProcess"
             DECLARE @insureeToDelete TABLE(CHFID NVARCHAR(12))
             INSERT INTO @insureeToDelete(CHFID)
-            SELECT CHFID
-            FROM (
-            SELECT CHFID FROM @insureeToProcess
-            UNION ALL
-            SELECT CHFID FROM @tblInsuree TI
-            ) tbl
-            GROUP BY CHFID
-            HAVING count(*) = 1
-            ORDER BY CHFID;
+            SELECT IP.CHFID FROM @insureeToProcess IP
+            LEFT JOIN @tblInsuree I ON I.CHFID=IP.CHFID
+            WHERE I.CHFID is NULL
 
             -- iterate through insuree to delete - process them to remove from existing family
             -- use SP uspAPIDeleteMemberFamily and 'delete' InsureePolicy also like in webapp 


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-324

In that PR I want to add missing part (deleting insuree from family based on received XML payload) in uspConsumeEnrollment. When we have no insuree in payload - then we can delete this one using SP 'uspAPIDeleteMemberFamily' and updateTblInsureePolicy with setting validityTo.

Earlier such case wasn't implemented and that is why this TestCase doesn't pass scenario after synch in policy mobile app. 