### PR TITLE
OTC-243: added rights for claim admin to enquire insuree

### DIFF
--- a/Migration script/openIMIS migration latest.sql
+++ b/Migration script/openIMIS migration latest.sql
@@ -1514,6 +1514,13 @@ BEGIN
 	VALUES (@SystemRole, 111012, CURRENT_TIMESTAMP)
 END 
 
+-- OTC-243 Enquiry in IMIS Claims doesn't function.
+IF NOT EXISTS (SELECT * FROM [tblRoleRight] WHERE [RoleID] = @SystemRole AND [RightID] = 101105)
+BEGIN
+	INSERT [dbo].[tblRoleRight] ([RoleID], [RightID], [ValidityFrom]) 
+	VALUES (@SystemRole, 101105, CURRENT_TIMESTAMP)
+END
+
 -- OP-141: Fixing uspSSRSCapitationPayment stored procedure
 
 SET ANSI_NULLS ON


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-243

There is no rights on MV to enquire insuree for "claim administrator" role.
After applying this claims enquire should work like in below screenshot from emulator.
![otc-243](https://user-images.githubusercontent.com/52816247/115865663-eca08a00-a438-11eb-9421-94efdb544781.PNG)