### PR TITLE
OP-454: Add Usage field to the tblIMISDefaultsPhone to explain the fields

### DIFF
--- a/Empty databases/openIMIS_ONLINE.sql
+++ b/Empty databases/openIMIS_ONLINE.sql
@@ -2616,7 +2616,8 @@ SET QUOTED_IDENTIFIER ON
 GO
 CREATE TABLE [dbo].[tblIMISDefaultsPhone](
 	[RuleName] [nvarchar](100) NULL,
-	[RuleValue] [bit] NULL
+	[RuleValue] [bit] NULL,
+	[Usage] [nvarchar](200) NULL
 ) ON [PRIMARY]
 GO
 
@@ -4982,9 +4983,10 @@ SET IDENTITY_INSERT [dbo].[tblIMISDefaults] ON
 
 INSERT [dbo].[tblIMISDefaults] ([DefaultID], [PolicyRenewalInterval], [FTPHost], [FTPUser], [FTPPassword], [FTPPort], [FTPEnrollmentFolder], [AssociatedPhotoFolder], [FTPClaimFolder], [FTPFeedbackFolder], [FTPPolicyRenewalFolder], [FTPPhoneExtractFolder], [FTPOffLineExtractFolder], [AppVersionBackEnd], [AppVersionEnquire], [AppVersionEnroll], [AppVersionRenewal], [AppVersionFeedback], [AppVersionClaim], [OffLineHF], [WinRarFolder], [DatabaseBackupFolder], [OfflineCHF], [SMSLink], [SMSIP], [SMSUserName], [SMSPassword], [SMSSource], [SMSDlr], [SMSType], [AppVersionFeedbackRenewal], [AppVersionImis]) VALUES (1, 14, N'', N'', N'', 0, N'/Images/Submitted', N'/Images/Updated', N'', N'', N'', N'', N'', CAST(1.2 AS Decimal(3, 1)), CAST(0.0 AS Decimal(3, 1)), CAST(0.0 AS Decimal(3, 1)), CAST(0.0 AS Decimal(3, 1)), CAST(0.0 AS Decimal(3, 1)), CAST(0.0 AS Decimal(3, 1)), 0, N'C:\Program Files (x86)\WinRAR\', N'', 0, N'', N'', N'', N'', N'', 1, 1, CAST(1.2 AS Decimal(3, 1)), CAST(0.0 AS Decimal(3, 1)))
 SET IDENTITY_INSERT [dbo].[tblIMISDefaults] OFF
-INSERT [dbo].[tblIMISDefaultsPhone] ([RuleName], [RuleValue]) VALUES (N'AllowInsureeWithoutPhoto', 0)
-INSERT [dbo].[tblIMISDefaultsPhone] ([RuleName], [RuleValue]) VALUES (N'AllowFamilyWithoutPolicy', 0)
-INSERT [dbo].[tblIMISDefaultsPhone] ([RuleName], [RuleValue]) VALUES (N'AllowPolicyWithoutPremium', 0)
+INSERT [dbo].[tblIMISDefaultsPhone] ([RuleName], [RuleValue], [Usage]) VALUES (N'AllowInsureeWithoutPhoto', 0, 'Allow synchronization of Insurees without a Photo.')
+INSERT [dbo].[tblIMISDefaultsPhone] ([RuleName], [RuleValue], [Usage]) VALUES (N'AllowFamilyWithoutPolicy', 0, 'Allow synchronization of Families without a Policy.')
+INSERT [dbo].[tblIMISDefaultsPhone] ([RuleName], [RuleValue], [Usage]) VALUES (N'AllowPolicyWithoutPremium', 0, 'Allow synchronization of Policies without a Contribution. If ShowPaymentOption is false, this rule value is read as true.')
+INSERT [dbo].[tblIMISDefaultsPhone] ([RuleName], [RuleValue], [Usage]) VALUES (N'ShowPaymentOption', 1, 'Show or hide the Payment option to allow or not to add a Contribution for a Policy. ')
 INSERT [dbo].[tblLanguages] ([LanguageCode], [LanguageName], [SortOrder]) VALUES (N'en', N'English', 1) -- By default english is set as primary language, required by SMS
 INSERT [dbo].[tblLanguages] ([LanguageCode], [LanguageName], [SortOrder]) VALUES (N'fr', N'Français', 2)
 INSERT [dbo].[tblLegalForms] ([LegalFormCode], [LegalForms], [SortOrder], [AltLanguage]) VALUES (N'C', N'Charity', NULL, N'Charité')

--- a/Migration script/openIMIS migration latest.sql
+++ b/Migration script/openIMIS migration latest.sql
@@ -8612,3 +8612,26 @@ GO
 IF COL_LENGTH(N'tblItems', N'Quantity')  IS NULL
 ALTER TABLE tblItems ADD Quantity DECIMAL(18, 2) NULL
 GO
+
+IF NOT EXISTS(SELECT RuleName from tblIMISDefaultsPhone WHERE RuleName='ShowPaymentOption')
+	INSERT INTO tblIMISDefaultsPhone(RuleName, RuleValue) VALUES('ShowPaymentOption', 1)
+GO
+
+IF COL_LENGTH(N'dbo.tblIMISDefaultsPhone', N'Usage') IS NULL
+	ALTER TABLE [dbo].[tblIMISDefaultsPhone] ADD [Usage] [nvarchar](200) NULL
+GO
+
+IF EXISTS (SELECT [RuleName] FROM [dbo].[tblIMISDefaultsPhone]
+	WHERE [RuleName] in ('AllowInsureeWithoutPhoto', 'AllowFamilyWithoutPolicy', 'AllowPolicyWithoutPremium', 'ShowPaymentOption')
+	and [Usage] IS NULL)
+BEGIN
+	UPDATE	[dbo].[tblIMISDefaultsPhone]
+	SET [Usage] = CASE
+		WHEN [RuleName] = 'AllowInsureeWithoutPhoto' THEN 'Allow synchronization of Insurees without a Photo.'
+		WHEN [RuleName] = 'AllowFamilyWithoutPolicy' THEN 'Allow synchronization of Families without a Policy.'
+		WHEN [RuleName] = 'AllowPolicyWithoutPremium' THEN 'Allow synchronization of Policies without a Contribution. If ShowPaymentOption is false, this rule value is read as true.'
+		WHEN [RuleName] = 'ShowPaymentOption' THEN 'Show or hide the Payment option to allow or not to add a Contribution for a Policy.'
+		END
+	WHERE [RuleName] in ('AllowInsureeWithoutPhoto', 'AllowFamilyWithoutPolicy', 'AllowPolicyWithoutPremium', 'ShowPaymentOption')
+END
+GO


### PR DESCRIPTION
Changes:
- `Usage` column added to `tblIMISDefaultsPhone`
- `ShowPaymentOption` rule added to `tblIMISDefaultsPhone` with proper usage

[https://openimis.atlassian.net/browse/OP-454](https://openimis.atlassian.net/browse/OP-454)