### PR TITLE
OTC-528: PriceLists LocationId on a national level changed from 0 to NULL.

### DIFF
--- a/sql/migrations/1_migration_latest.sql
+++ b/sql/migrations/1_migration_latest.sql
@@ -9479,3 +9479,7 @@ IF COL_LENGTH(N'tblPayment', N'PhoneNumber') IS NOT NULL
 	ALTER TABLE tblPayment
 	ALTER COLUMN PhoneNumber NVARCHAR(50) NULL
 GO
+
+--OTC-528
+UPDATE tblPLItems SET LocationId=NULL WHERE LocationId=0
+UPDATE tblPLServices SET LocationId=NULL WHERE LocationId=0


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-528

Changes:
- PriceList Items and PriceList Services LocationId changed from 0 to NULL when indicating national level.
- Migration is applied to every record (even when ValidityTo is not NULL) to ensure consistency and possibility of retrevial of historical data with one query.