### PR TITLE
OTC-643 Effective date of CHF policy

### DIFF
--- a/sql/migrations/1_migration_latest.sql
+++ b/sql/migrations/1_migration_latest.sql
@@ -3488,3 +3488,9 @@ CREATE NONCLUSTERED INDEX [NCI_tblInsureePolicy_PolicyID] ON [dbo].[tblInsureePo
 	[PolicyId] ASC
 )WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, SORT_IN_TEMPDB = OFF, DROP_EXISTING = OFF, ONLINE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON, FILLFACTOR = 80, OPTIMIZE_FOR_SEQUENTIAL_KEY = OFF) ON [IndexesFG]
 GO
+
+-- OTC-643 Update all idle policies (before payment/contribution) effective date from 1900-01-01 to NULL
+UPDATE tblPolicy
+SET EffectiveDate = NULL
+WHERE ValidityTo IS NULL AND EffectiveDate = '1900-01-01' and PolicyStatus = 1
+GO

--- a/sql/stored_procedures/uspConsumeEnrollments.sql
+++ b/sql/stored_procedures/uspConsumeEnrollments.sql
@@ -125,7 +125,7 @@ CREATE PROCEDURE [dbo].[uspConsumeEnrollments](
 		T.P.value('(FamilyId)[1]','INT'),
 		T.P.value('(EnrollDate)[1]','DATE'),
 		T.P.value('(StartDate)[1]','DATE'),
-		T.P.value('(EffectiveDate)[1]','DATE'),
+		NULLIF(T.P.value('(EffectiveDate)[1]','DATE'),''),
 		T.P.value('(ExpiryDate)[1]','DATE'),
 		IIF(T.P.value('(PolicyStatus)[1]','TINYINT') = @ActiveStatus AND @ActivationOption = 3, @ReadyStatus, T.P.value('(PolicyStatus)[1]','TINYINT')),
 		T.P.value('(PolicyValue)[1]','DECIMAL(18,2)'),


### PR DESCRIPTION
Changes:
- Fixed assignment of `EffectiveDate` is `uspConsumeEnrolments` before payment/contribution
- Migrated all idle policies with `EffectiveDate` of `1900-01-01` to `NULL` 